### PR TITLE
Specify C++11 standard for building on Windows and Unix

### DIFF
--- a/beatwhale.pro
+++ b/beatwhale.pro
@@ -5,6 +5,10 @@ ROOT_DIR = ../..
 macx {
     CONFIG+= app_bundle
     CONFIG += c++11
+} win32 {
+    CONFIG += c++11
+} unix {
+    CONFIG += c++11
 }
 
 CONFIG(debug, debug|release): DESTDIR = $${ROOT_DIR}/Output/debug


### PR DESCRIPTION
Qt complained that there was no support for ISO C++11 on ubuntu and win8. It was only specified for mac.
